### PR TITLE
Modify asserts based on whether or not the property is required

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -169,8 +169,9 @@ fn generate(openapi: openapiv3::OpenAPI, output_directory: PathBuf) -> Result<()
                                 continue;
                             }
                             let schema = schema.unwrap().as_item().unwrap();
+                            let is_required = true;
                             let mut new_asserts =
-                                generate_assert_from_schema(&openapi, schema, "$");
+                                generate_assert_from_schema(&openapi, schema, "$", is_required);
                             asserts.append(&mut new_asserts);
                         }
                         openapiv3::ReferenceOr::Item(item) => {
@@ -188,8 +189,9 @@ fn generate(openapi: openapiv3::OpenAPI, output_directory: PathBuf) -> Result<()
                                 continue;
                             }
                             let schema = schema.unwrap();
+                            let is_required = true;
                             let mut new_asserts =
-                                generate_assert_from_schema(&openapi, schema, "$");
+                                generate_assert_from_schema(&openapi, schema, "$", is_required);
                             asserts.append(&mut new_asserts);
                         }
                     };
@@ -259,21 +261,34 @@ fn generate_assert_from_schema(
     openapi: &openapiv3::OpenAPI,
     schema: &openapiv3::Schema,
     jsonpath: &str,
+    is_required: bool,
 ) -> Vec<String> {
     let mut asserts = vec![];
+    let is_required_formatter = |jsonpath: &str, default: &str, is_required: bool| -> String {
+        format!(
+            "{}jsonpath \"{}\" {}",
+            if is_required { "" } else { "#" },
+            jsonpath,
+            default
+        )
+    };
     if let openapiv3::SchemaKind::Type(schema_type) = &schema.schema_kind {
         match schema_type {
             openapiv3::Type::String(_) => {
-                asserts.push(format!("jsonpath \"{}\" isString", jsonpath))
+                asserts.push(is_required_formatter(&jsonpath, "isString", is_required))
             }
             openapiv3::Type::Number(_) => {
-                asserts.push(format!("jsonpath \"{}\" isNumber", jsonpath))
+                asserts.push(is_required_formatter(&jsonpath, "isNumber", is_required))
             }
             openapiv3::Type::Integer(_) => {
-                asserts.push(format!("jsonpath \"{}\" isInteger", jsonpath))
+                asserts.push(is_required_formatter(&jsonpath, "isInteger", is_required))
             }
             openapiv3::Type::Object(ob) => {
-                asserts.push(format!("jsonpath \"{}\" isCollection", jsonpath));
+                asserts.push(is_required_formatter(
+                    &jsonpath,
+                    "isCollection",
+                    is_required,
+                ));
                 let properties = &ob.properties;
                 for (name, prop) in properties.iter() {
                     let inner = resolve_schema_box(openapi, prop);
@@ -289,8 +304,13 @@ fn generate_assert_from_schema(
                     } else {
                         format!("{}.{}", jsonpath, name)
                     };
-                    let mut child_asserts =
-                        generate_assert_from_schema(openapi, inner, inner_jsonpath.as_ref());
+                    let child_is_required = is_required && ob.required.contains(name);
+                    let mut child_asserts = generate_assert_from_schema(
+                        openapi,
+                        inner,
+                        inner_jsonpath.as_ref(),
+                        child_is_required,
+                    );
                     asserts.append(&mut child_asserts);
                 }
             }

--- a/src/snapshots/heave__tests__petstore@addPet_200.hurl.snap
+++ b/src/snapshots/heave__tests__petstore@addPet_200.hurl.snap
@@ -27,13 +27,17 @@ HTTP 200
 
 [Asserts]
 jsonpath "$" isCollection
-jsonpath "$.id" isInteger
+#jsonpath "$.id" isInteger
 jsonpath "$.name" isString
-jsonpath "$.category" isCollection
-jsonpath "$.category.id" isInteger
-jsonpath "$.category.name" isString
+#jsonpath "$.category" isCollection
+#jsonpath "$.category.id" isInteger
+#jsonpath "$.category.name" isString
 jsonpath "$.photoUrls" isCollection
-jsonpath "$.tags" isCollection
-jsonpath "$.status" isString
+#jsonpath "$.photoUrls[0]" isString
+#jsonpath "$.tags" isCollection
+#jsonpath "$.tags[0]" isCollection
+#jsonpath "$.tags[0].id" isInteger
+#jsonpath "$.tags[0].name" isString
+#jsonpath "$.status" isString
 
 

--- a/src/snapshots/heave__tests__petstore@findPetsByStatus_200.hurl.snap
+++ b/src/snapshots/heave__tests__petstore@findPetsByStatus_200.hurl.snap
@@ -13,5 +13,18 @@ HTTP 200
 
 [Asserts]
 jsonpath "$" isCollection
+#jsonpath "$[0]" isCollection
+#jsonpath "$[0].id" isInteger
+#jsonpath "$[0].name" isString
+#jsonpath "$[0].category" isCollection
+#jsonpath "$[0].category.id" isInteger
+#jsonpath "$[0].category.name" isString
+#jsonpath "$[0].photoUrls" isCollection
+#jsonpath "$[0].photoUrls[0]" isString
+#jsonpath "$[0].tags" isCollection
+#jsonpath "$[0].tags[0]" isCollection
+#jsonpath "$[0].tags[0].id" isInteger
+#jsonpath "$[0].tags[0].name" isString
+#jsonpath "$[0].status" isString
 
 

--- a/src/snapshots/heave__tests__petstore@findPetsByTags_200.hurl.snap
+++ b/src/snapshots/heave__tests__petstore@findPetsByTags_200.hurl.snap
@@ -13,5 +13,18 @@ HTTP 200
 
 [Asserts]
 jsonpath "$" isCollection
+#jsonpath "$[0]" isCollection
+#jsonpath "$[0].id" isInteger
+#jsonpath "$[0].name" isString
+#jsonpath "$[0].category" isCollection
+#jsonpath "$[0].category.id" isInteger
+#jsonpath "$[0].category.name" isString
+#jsonpath "$[0].photoUrls" isCollection
+#jsonpath "$[0].photoUrls[0]" isString
+#jsonpath "$[0].tags" isCollection
+#jsonpath "$[0].tags[0]" isCollection
+#jsonpath "$[0].tags[0].id" isInteger
+#jsonpath "$[0].tags[0].name" isString
+#jsonpath "$[0].status" isString
 
 

--- a/src/snapshots/heave__tests__petstore@getPetById_200.hurl.snap
+++ b/src/snapshots/heave__tests__petstore@getPetById_200.hurl.snap
@@ -10,13 +10,17 @@ HTTP 200
 
 [Asserts]
 jsonpath "$" isCollection
-jsonpath "$.id" isInteger
+#jsonpath "$.id" isInteger
 jsonpath "$.name" isString
-jsonpath "$.category" isCollection
-jsonpath "$.category.id" isInteger
-jsonpath "$.category.name" isString
+#jsonpath "$.category" isCollection
+#jsonpath "$.category.id" isInteger
+#jsonpath "$.category.name" isString
 jsonpath "$.photoUrls" isCollection
-jsonpath "$.tags" isCollection
-jsonpath "$.status" isString
+#jsonpath "$.photoUrls[0]" isString
+#jsonpath "$.tags" isCollection
+#jsonpath "$.tags[0]" isCollection
+#jsonpath "$.tags[0].id" isInteger
+#jsonpath "$.tags[0].name" isString
+#jsonpath "$.status" isString
 
 

--- a/src/snapshots/heave__tests__petstore@updatePet_200.hurl.snap
+++ b/src/snapshots/heave__tests__petstore@updatePet_200.hurl.snap
@@ -27,13 +27,17 @@ HTTP 200
 
 [Asserts]
 jsonpath "$" isCollection
-jsonpath "$.id" isInteger
+#jsonpath "$.id" isInteger
 jsonpath "$.name" isString
-jsonpath "$.category" isCollection
-jsonpath "$.category.id" isInteger
-jsonpath "$.category.name" isString
+#jsonpath "$.category" isCollection
+#jsonpath "$.category.id" isInteger
+#jsonpath "$.category.name" isString
 jsonpath "$.photoUrls" isCollection
-jsonpath "$.tags" isCollection
-jsonpath "$.status" isString
+#jsonpath "$.photoUrls[0]" isString
+#jsonpath "$.tags" isCollection
+#jsonpath "$.tags[0]" isCollection
+#jsonpath "$.tags[0].id" isInteger
+#jsonpath "$.tags[0].name" isString
+#jsonpath "$.status" isString
 
 

--- a/src/snapshots/petstore/addPet_200.hurl
+++ b/src/snapshots/petstore/addPet_200.hurl
@@ -29,6 +29,10 @@ jsonpath "$.name" isString
 #jsonpath "$.category.id" isInteger
 #jsonpath "$.category.name" isString
 jsonpath "$.photoUrls" isCollection
-jsonpath "$.tags" isCollection
+#jsonpath "$.photoUrls[0]" isString
+#jsonpath "$.tags" isCollection
+#jsonpath "$.tags[0]" isCollection
+#jsonpath "$.tags[0].id" isInteger
+#jsonpath "$.tags[0].name" isString
 #jsonpath "$.status" isString
 

--- a/src/snapshots/petstore/addPet_200.hurl
+++ b/src/snapshots/petstore/addPet_200.hurl
@@ -23,12 +23,12 @@ HTTP 200
 
 [Asserts]
 jsonpath "$" isCollection
-jsonpath "$.id" isInteger
+#jsonpath "$.id" isInteger
 jsonpath "$.name" isString
-jsonpath "$.category" isCollection
-jsonpath "$.category.id" isInteger
-jsonpath "$.category.name" isString
+#jsonpath "$.category" isCollection
+#jsonpath "$.category.id" isInteger
+#jsonpath "$.category.name" isString
 jsonpath "$.photoUrls" isCollection
 jsonpath "$.tags" isCollection
-jsonpath "$.status" isString
+#jsonpath "$.status" isString
 

--- a/src/snapshots/petstore/findPetsByStatus_200.hurl
+++ b/src/snapshots/petstore/findPetsByStatus_200.hurl
@@ -9,4 +9,17 @@ HTTP 200
 
 [Asserts]
 jsonpath "$" isCollection
+#jsonpath "$[0]" isCollection
+#jsonpath "$[0].id" isInteger
+#jsonpath "$[0].name" isString
+#jsonpath "$[0].category" isCollection
+#jsonpath "$[0].category.id" isInteger
+#jsonpath "$[0].category.name" isString
+#jsonpath "$[0].photoUrls" isCollection
+#jsonpath "$[0].photoUrls[0]" isString
+#jsonpath "$[0].tags" isCollection
+#jsonpath "$[0].tags[0]" isCollection
+#jsonpath "$[0].tags[0].id" isInteger
+#jsonpath "$[0].tags[0].name" isString
+#jsonpath "$[0].status" isString
 

--- a/src/snapshots/petstore/findPetsByTags_200.hurl
+++ b/src/snapshots/petstore/findPetsByTags_200.hurl
@@ -9,4 +9,17 @@ HTTP 200
 
 [Asserts]
 jsonpath "$" isCollection
+#jsonpath "$[0]" isCollection
+#jsonpath "$[0].id" isInteger
+#jsonpath "$[0].name" isString
+#jsonpath "$[0].category" isCollection
+#jsonpath "$[0].category.id" isInteger
+#jsonpath "$[0].category.name" isString
+#jsonpath "$[0].photoUrls" isCollection
+#jsonpath "$[0].photoUrls[0]" isString
+#jsonpath "$[0].tags" isCollection
+#jsonpath "$[0].tags[0]" isCollection
+#jsonpath "$[0].tags[0].id" isInteger
+#jsonpath "$[0].tags[0].name" isString
+#jsonpath "$[0].status" isString
 

--- a/src/snapshots/petstore/getPetById_200.hurl
+++ b/src/snapshots/petstore/getPetById_200.hurl
@@ -6,12 +6,12 @@ HTTP 200
 
 [Asserts]
 jsonpath "$" isCollection
-jsonpath "$.id" isInteger
+#jsonpath "$.id" isInteger
 jsonpath "$.name" isString
-jsonpath "$.category" isCollection
-jsonpath "$.category.id" isInteger
-jsonpath "$.category.name" isString
+#jsonpath "$.category" isCollection
+#jsonpath "$.category.id" isInteger
+#jsonpath "$.category.name" isString
 jsonpath "$.photoUrls" isCollection
 jsonpath "$.tags" isCollection
-jsonpath "$.status" isString
+#jsonpath "$.status" isString
 

--- a/src/snapshots/petstore/getPetById_200.hurl
+++ b/src/snapshots/petstore/getPetById_200.hurl
@@ -12,6 +12,10 @@ jsonpath "$.name" isString
 #jsonpath "$.category.id" isInteger
 #jsonpath "$.category.name" isString
 jsonpath "$.photoUrls" isCollection
-jsonpath "$.tags" isCollection
+#jsonpath "$.photoUrls[0]" isString
+#jsonpath "$.tags" isCollection
+#jsonpath "$.tags[0]" isCollection
+#jsonpath "$.tags[0].id" isInteger
+#jsonpath "$.tags[0].name" isString
 #jsonpath "$.status" isString
 

--- a/src/snapshots/petstore/updatePet_200.hurl
+++ b/src/snapshots/petstore/updatePet_200.hurl
@@ -29,6 +29,10 @@ jsonpath "$.name" isString
 #jsonpath "$.category.id" isInteger
 #jsonpath "$.category.name" isString
 jsonpath "$.photoUrls" isCollection
-jsonpath "$.tags" isCollection
+#jsonpath "$.photoUrls[0]" isString
+#jsonpath "$.tags" isCollection
+#jsonpath "$.tags[0]" isCollection
+#jsonpath "$.tags[0].id" isInteger
+#jsonpath "$.tags[0].name" isString
 #jsonpath "$.status" isString
 

--- a/src/snapshots/petstore/updatePet_200.hurl
+++ b/src/snapshots/petstore/updatePet_200.hurl
@@ -23,12 +23,12 @@ HTTP 200
 
 [Asserts]
 jsonpath "$" isCollection
-jsonpath "$.id" isInteger
+#jsonpath "$.id" isInteger
 jsonpath "$.name" isString
-jsonpath "$.category" isCollection
-jsonpath "$.category.id" isInteger
-jsonpath "$.category.name" isString
+#jsonpath "$.category" isCollection
+#jsonpath "$.category.id" isInteger
+#jsonpath "$.category.name" isString
 jsonpath "$.photoUrls" isCollection
 jsonpath "$.tags" isCollection
-jsonpath "$.status" isString
+#jsonpath "$.status" isString
 


### PR DESCRIPTION
## Description
This PR will generate asserts that are commented out if the property is optional. The behavior works like this:
- If the name of the field is in the objects `required` attribute, it will generate with a non-commented out assert
- If the name of the field **is not** in the objects `required` attribute, it will **not** generate with a non-commented out assert
- If an object is optional, all of it's children asserts will be commented out

Bonus feature introduced:
When generating asserts for arrays, asserts for the type in the array will also be generated. Since lists can always be empty, these asserts are always generated commented out.