### PR TITLE
Template subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,47 @@ heave is a tool used to generate [hurl](https://github.com/Orange-OpenSource/hur
 
 These files can be used for testing or iterating on feature development.
 
-## Testing
+## Motivation
+I started on this tool because I was unhappy with the current solutions for
+sharing examples of requests. Plain text files are nice to read, easy to
+change, and work well under version control. Hurl has an easy interface that
+lets you use these files to help you iterate on a feature or run them as tests
+and assert on the output.
+
+## Getting Started
+Assuming you have your spec and an output directory created, you use `heave` like this:
+```
+heave generate <spec.yaml> <output>
+```
+This will create one hurl file per operation per response. Meaning, if you had
+an OAS with a single `ListPets` operation that had an HTTP 200 response and an
+404 HTTP response defined, you would get 2 files.
+
+These generated files should include:
+- The correct HTTP method (GET, POST, etc.)
+- A templated path, using hurl variables as path parameters
+- Header parameters (if defined)
+- Query parameters (if defined)
+- Request Body (if defined)
+- Asserts based on the response schema
+
+You will most likely need to go through each file and customize some aspects of
+the request, but I hope this tool handles a lot of the foundation for you.
+
+#### Customizing the template
+This tool does allow you to also customize the template used to generate it.
+This tool relies on the [minijinja](https://crates.io/crates/minijinja) crate
+for templating. If you'd like to customize the template you can use `heave
+template` to print the default template. Put that content into a file with your
+changes. Then call `heave` again with your custom template:
+```
+heave generate <spec.yaml> <output> --template <template>
+```
+With this functionality you could include additional headers or remove asserts
+entirely.
+
+## Contributing
+#### Testing
 This project uses [cargo-insta](https://crates.io/crates/cargo-insta) to create
 snapshots of the output to test against. Insta provides a tool that makes
 running these tests and reviewing their output easier. To install it run `cargo
@@ -12,7 +52,7 @@ install cargo-insta`. Once this is installed, changes can be reviewed with
 
 If you're just trying to run the tests you can run `cargo test`.
 
-## Releasing
+#### Releasing
 This project uses [cargo-dist](https://opensource.axo.dev/cargo-dist/) and
 [cargo-release](https://github.com/crate-ci/cargo-release) for the release
 process.

--- a/src/snapshots/heave__tests__petstore@findPetsByStatus_200.hurl.snap
+++ b/src/snapshots/heave__tests__petstore@findPetsByStatus_200.hurl.snap
@@ -7,7 +7,7 @@ Authorization: Bearer {{ authorization }}
 Prefer: code=200
 
 [QueryStringParams]
-status: 
+status:
 
 HTTP 200
 
@@ -26,5 +26,4 @@ jsonpath "$" isCollection
 #jsonpath "$[0].tags[0].id" isInteger
 #jsonpath "$[0].tags[0].name" isString
 #jsonpath "$[0].status" isString
-
 

--- a/src/snapshots/heave__tests__petstore@findPetsByTags_200.hurl.snap
+++ b/src/snapshots/heave__tests__petstore@findPetsByTags_200.hurl.snap
@@ -7,7 +7,7 @@ Authorization: Bearer {{ authorization }}
 Prefer: code=200
 
 [QueryStringParams]
-tags: 
+tags:
 
 HTTP 200
 
@@ -26,5 +26,4 @@ jsonpath "$" isCollection
 #jsonpath "$[0].tags[0].id" isInteger
 #jsonpath "$[0].tags[0].name" isString
 #jsonpath "$[0].status" isString
-
 

--- a/src/snapshots/petstore/addPet_200.hurl
+++ b/src/snapshots/petstore/addPet_200.hurl
@@ -35,4 +35,3 @@ jsonpath "$.photoUrls" isCollection
 #jsonpath "$.tags[0].id" isInteger
 #jsonpath "$.tags[0].name" isString
 #jsonpath "$.status" isString
-

--- a/src/snapshots/petstore/findPetsByStatus_200.hurl
+++ b/src/snapshots/petstore/findPetsByStatus_200.hurl
@@ -3,7 +3,7 @@ Authorization: Bearer {{ authorization }}
 Prefer: code=200
 
 [QueryStringParams]
-status: 
+status:
 
 HTTP 200
 
@@ -22,4 +22,3 @@ jsonpath "$" isCollection
 #jsonpath "$[0].tags[0].id" isInteger
 #jsonpath "$[0].tags[0].name" isString
 #jsonpath "$[0].status" isString
-

--- a/src/snapshots/petstore/findPetsByTags_200.hurl
+++ b/src/snapshots/petstore/findPetsByTags_200.hurl
@@ -3,7 +3,7 @@ Authorization: Bearer {{ authorization }}
 Prefer: code=200
 
 [QueryStringParams]
-tags: 
+tags:
 
 HTTP 200
 
@@ -22,4 +22,3 @@ jsonpath "$" isCollection
 #jsonpath "$[0].tags[0].id" isInteger
 #jsonpath "$[0].tags[0].name" isString
 #jsonpath "$[0].status" isString
-

--- a/src/snapshots/petstore/getPetById_200.hurl
+++ b/src/snapshots/petstore/getPetById_200.hurl
@@ -18,4 +18,3 @@ jsonpath "$.photoUrls" isCollection
 #jsonpath "$.tags[0].id" isInteger
 #jsonpath "$.tags[0].name" isString
 #jsonpath "$.status" isString
-

--- a/src/snapshots/petstore/updatePet_200.hurl
+++ b/src/snapshots/petstore/updatePet_200.hurl
@@ -35,4 +35,3 @@ jsonpath "$.photoUrls" isCollection
 #jsonpath "$.tags[0].id" isInteger
 #jsonpath "$.tags[0].name" isString
 #jsonpath "$.status" isString
-


### PR DESCRIPTION
## Description
This PR splits the CLI interface into 2 subcommands:
- `generate`
- `template`

The generate command will handle all the initial functionality of generating the hurl files. The new `template` command prints the default template to stdout. This is useful because another feature added in this PR is the ability to use a custom template:
```
heave generate <spec> <output> --template <template file>
```
This will allow users to inject a custom minijinja template.