### PR TITLE
fix: early return when request body not application/json

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -186,7 +186,7 @@ fn generate(
             }
         }
 
-        if let Some(request_body) = &operation.request_body {
+        while let Some(request_body) = &operation.request_body {
             let request_body = resolve_request_body(&openapi, &request_body);
             if request_body.is_none() {
                 break;
@@ -221,6 +221,7 @@ fn generate(
                     request_body_parameter = Some(body);
                 }
             };
+            break;
         }
 
         for (status_code, response) in operation.responses.responses.iter() {

--- a/src/snapshots/heave__tests__petstore@createUsersWithListInput_200.hurl.snap
+++ b/src/snapshots/heave__tests__petstore@createUsersWithListInput_200.hurl.snap
@@ -1,0 +1,32 @@
+---
+source: src/main.rs
+input_file: src/snapshots/petstore/createUsersWithListInput_200.hurl
+---
+POST {{ baseurl }}/user/createWithList
+Authorization: Bearer {{ authorization }}
+Prefer: code=200
+[
+  {
+    "email": "",
+    "firstName": "",
+    "id": 0,
+    "lastName": "",
+    "password": "",
+    "phone": "",
+    "userStatus": 0,
+    "username": ""
+  }
+]
+HTTP 200
+
+[Asserts]
+jsonpath "$" isCollection
+#jsonpath "$.id" isInteger
+#jsonpath "$.username" isString
+#jsonpath "$.firstName" isString
+#jsonpath "$.lastName" isString
+#jsonpath "$.email" isString
+#jsonpath "$.password" isString
+#jsonpath "$.phone" isString
+#jsonpath "$.userStatus" isInteger
+

--- a/src/snapshots/heave__tests__petstore@getInventory_200.hurl.snap
+++ b/src/snapshots/heave__tests__petstore@getInventory_200.hurl.snap
@@ -1,0 +1,13 @@
+---
+source: src/main.rs
+input_file: src/snapshots/petstore/getInventory_200.hurl
+---
+GET {{ baseurl }}/store/inventory
+Authorization: Bearer {{ authorization }}
+Prefer: code=200
+
+HTTP 200
+
+[Asserts]
+jsonpath "$" isCollection
+

--- a/src/snapshots/heave__tests__petstore@getOrderById_200.hurl.snap
+++ b/src/snapshots/heave__tests__petstore@getOrderById_200.hurl.snap
@@ -1,0 +1,19 @@
+---
+source: src/main.rs
+input_file: src/snapshots/petstore/getOrderById_200.hurl
+---
+GET {{ baseurl }}/store/order/{{orderId}}
+Authorization: Bearer {{ authorization }}
+Prefer: code=200
+
+HTTP 200
+
+[Asserts]
+jsonpath "$" isCollection
+#jsonpath "$.id" isInteger
+#jsonpath "$.petId" isInteger
+#jsonpath "$.quantity" isInteger
+#jsonpath "$.shipDate" isString
+#jsonpath "$.status" isString
+#jsonpath "$.complete" isBoolean
+

--- a/src/snapshots/heave__tests__petstore@getUserByName_200.hurl.snap
+++ b/src/snapshots/heave__tests__petstore@getUserByName_200.hurl.snap
@@ -1,0 +1,21 @@
+---
+source: src/main.rs
+input_file: src/snapshots/petstore/getUserByName_200.hurl
+---
+GET {{ baseurl }}/user/{{username}}
+Authorization: Bearer {{ authorization }}
+Prefer: code=200
+
+HTTP 200
+
+[Asserts]
+jsonpath "$" isCollection
+#jsonpath "$.id" isInteger
+#jsonpath "$.username" isString
+#jsonpath "$.firstName" isString
+#jsonpath "$.lastName" isString
+#jsonpath "$.email" isString
+#jsonpath "$.password" isString
+#jsonpath "$.phone" isString
+#jsonpath "$.userStatus" isInteger
+

--- a/src/snapshots/heave__tests__petstore@loginUser_200.hurl.snap
+++ b/src/snapshots/heave__tests__petstore@loginUser_200.hurl.snap
@@ -1,0 +1,17 @@
+---
+source: src/main.rs
+input_file: src/snapshots/petstore/loginUser_200.hurl
+---
+GET {{ baseurl }}/user/login
+Authorization: Bearer {{ authorization }}
+Prefer: code=200
+
+[QueryStringParams]
+username:
+password:
+
+HTTP 200
+
+[Asserts]
+jsonpath "$" isString
+

--- a/src/snapshots/heave__tests__petstore@placeOrder_200.hurl.snap
+++ b/src/snapshots/heave__tests__petstore@placeOrder_200.hurl.snap
@@ -1,0 +1,26 @@
+---
+source: src/main.rs
+input_file: src/snapshots/petstore/placeOrder_200.hurl
+---
+POST {{ baseurl }}/store/order
+Authorization: Bearer {{ authorization }}
+Prefer: code=200
+{
+  "complete": false,
+  "id": 0,
+  "petId": 0,
+  "quantity": 0,
+  "shipDate": "",
+  "status": ""
+}
+HTTP 200
+
+[Asserts]
+jsonpath "$" isCollection
+#jsonpath "$.id" isInteger
+#jsonpath "$.petId" isInteger
+#jsonpath "$.quantity" isInteger
+#jsonpath "$.shipDate" isString
+#jsonpath "$.status" isString
+#jsonpath "$.complete" isBoolean
+

--- a/src/snapshots/heave__tests__petstore@uploadFile_200.hurl.snap
+++ b/src/snapshots/heave__tests__petstore@uploadFile_200.hurl.snap
@@ -1,0 +1,19 @@
+---
+source: src/main.rs
+input_file: src/snapshots/petstore/uploadFile_200.hurl
+---
+POST {{ baseurl }}/pet/{{petId}}/uploadImage
+Authorization: Bearer {{ authorization }}
+Prefer: code=200
+
+[QueryStringParams]
+additionalMetadata:
+
+HTTP 200
+
+[Asserts]
+jsonpath "$" isCollection
+#jsonpath "$.code" isInteger
+#jsonpath "$.type" isString
+#jsonpath "$.message" isString
+

--- a/src/snapshots/petstore/createUsersWithListInput_200.hurl
+++ b/src/snapshots/petstore/createUsersWithListInput_200.hurl
@@ -1,0 +1,27 @@
+POST {{ baseurl }}/user/createWithList
+Authorization: Bearer {{ authorization }}
+Prefer: code=200
+[
+  {
+    "email": "",
+    "firstName": "",
+    "id": 0,
+    "lastName": "",
+    "password": "",
+    "phone": "",
+    "userStatus": 0,
+    "username": ""
+  }
+]
+HTTP 200
+
+[Asserts]
+jsonpath "$" isCollection
+#jsonpath "$.id" isInteger
+#jsonpath "$.username" isString
+#jsonpath "$.firstName" isString
+#jsonpath "$.lastName" isString
+#jsonpath "$.email" isString
+#jsonpath "$.password" isString
+#jsonpath "$.phone" isString
+#jsonpath "$.userStatus" isInteger

--- a/src/snapshots/petstore/getInventory_200.hurl
+++ b/src/snapshots/petstore/getInventory_200.hurl
@@ -1,0 +1,8 @@
+GET {{ baseurl }}/store/inventory
+Authorization: Bearer {{ authorization }}
+Prefer: code=200
+
+HTTP 200
+
+[Asserts]
+jsonpath "$" isCollection

--- a/src/snapshots/petstore/getOrderById_200.hurl
+++ b/src/snapshots/petstore/getOrderById_200.hurl
@@ -1,0 +1,14 @@
+GET {{ baseurl }}/store/order/{{orderId}}
+Authorization: Bearer {{ authorization }}
+Prefer: code=200
+
+HTTP 200
+
+[Asserts]
+jsonpath "$" isCollection
+#jsonpath "$.id" isInteger
+#jsonpath "$.petId" isInteger
+#jsonpath "$.quantity" isInteger
+#jsonpath "$.shipDate" isString
+#jsonpath "$.status" isString
+#jsonpath "$.complete" isBoolean

--- a/src/snapshots/petstore/getUserByName_200.hurl
+++ b/src/snapshots/petstore/getUserByName_200.hurl
@@ -1,0 +1,16 @@
+GET {{ baseurl }}/user/{{username}}
+Authorization: Bearer {{ authorization }}
+Prefer: code=200
+
+HTTP 200
+
+[Asserts]
+jsonpath "$" isCollection
+#jsonpath "$.id" isInteger
+#jsonpath "$.username" isString
+#jsonpath "$.firstName" isString
+#jsonpath "$.lastName" isString
+#jsonpath "$.email" isString
+#jsonpath "$.password" isString
+#jsonpath "$.phone" isString
+#jsonpath "$.userStatus" isInteger

--- a/src/snapshots/petstore/loginUser_200.hurl
+++ b/src/snapshots/petstore/loginUser_200.hurl
@@ -1,0 +1,12 @@
+GET {{ baseurl }}/user/login
+Authorization: Bearer {{ authorization }}
+Prefer: code=200
+
+[QueryStringParams]
+username:
+password:
+
+HTTP 200
+
+[Asserts]
+jsonpath "$" isString

--- a/src/snapshots/petstore/placeOrder_200.hurl
+++ b/src/snapshots/petstore/placeOrder_200.hurl
@@ -1,0 +1,21 @@
+POST {{ baseurl }}/store/order
+Authorization: Bearer {{ authorization }}
+Prefer: code=200
+{
+  "complete": false,
+  "id": 0,
+  "petId": 0,
+  "quantity": 0,
+  "shipDate": "",
+  "status": ""
+}
+HTTP 200
+
+[Asserts]
+jsonpath "$" isCollection
+#jsonpath "$.id" isInteger
+#jsonpath "$.petId" isInteger
+#jsonpath "$.quantity" isInteger
+#jsonpath "$.shipDate" isString
+#jsonpath "$.status" isString
+#jsonpath "$.complete" isBoolean

--- a/src/snapshots/petstore/uploadFile_200.hurl
+++ b/src/snapshots/petstore/uploadFile_200.hurl
@@ -1,0 +1,14 @@
+POST {{ baseurl }}/pet/{{petId}}/uploadImage
+Authorization: Bearer {{ authorization }}
+Prefer: code=200
+
+[QueryStringParams]
+additionalMetadata:
+
+HTTP 200
+
+[Asserts]
+jsonpath "$" isCollection
+#jsonpath "$.code" isInteger
+#jsonpath "$.type" isString
+#jsonpath "$.message" isString


### PR DESCRIPTION
## Description
I found an issue where we'd bail early from parsing operations if there was a request body that did not contain an application/json media type. This means it was possible you could have an operation that took a non-json request and that would result in the next operations not generating any hurl files. The fix was just to use `while let` instead of `if let` so the breaks worked.