### PR TITLE
Fix panic allof ref any

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -906,7 +906,7 @@ fn generate_request_body_from_schema(
                         // empty JSON value and then flatten all the fields on to that single
                         // value. Any primitive fields can just be added directly to
                         // `child_request_bodies`.
-                        let mut j: serde_json::Value = serde_json::from_str(&body).unwrap();
+                        let mut j = serde_json::from_str::<serde_json::Value>(&body).unwrap();
                         if j.is_object() {
                             let inner_map = flattened_object_fields.as_object_mut().unwrap();
                             inner_map.append(&mut j.as_object_mut().unwrap());
@@ -920,6 +920,13 @@ fn generate_request_body_from_schema(
             if flattened_object_fields.as_object().unwrap().len() > 0 {
                 child_request_bodies.push(Some(flattened_object_fields.to_string()));
             }
+
+            // If child_request_bodies is empty we need to communicate that we couldn't build
+            // anything.
+            if child_request_bodies.is_empty() {
+                return (None, diagnostics);
+            }
+
             let stringified_body = child_request_bodies
                 .into_iter()
                 .filter_map(|body| body)

--- a/src/snapshots/allof/petstore.yaml
+++ b/src/snapshots/allof/petstore.yaml
@@ -121,6 +121,9 @@ components:
         status:
           allOf:
             - $ref: '#/components/schemas/PetPartStatus'
+        anyPart:
+          allOf:
+            - $ref: '#/components/schemas/AnyPart'
       type: object
     PetPartID:
       type: integer
@@ -148,6 +151,13 @@ components:
         - available
         - pending
         - sold
+    AnyPart:
+      description: >
+        This is a schema that deliberately looks like "Any" because it doesn't
+        use type, allOf, etc. It should not be present in thesnapshot test.
+      enum:
+        - any
+        - part
     CategoryPartID:
       description: "category description"
       type: object


### PR DESCRIPTION
## Description
Found a panic where it was possible for an `allOf` to resolve no fields. This happened specifically with an `Any` schema but could have happened with anything that returned None from `generate_request_body_from_schema`. These properties will be missing from the generated request body which matches current behavior with `Any` schema properties.