### PR TITLE
Cycle detection

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1306,6 +1306,20 @@ mod tests {
     }
 
     #[test]
+    fn cycle_detection() -> Result<(), Box<dyn Error>> {
+        let mut settings = insta::Settings::clone_current();
+        settings.set_omit_expression(true);
+        settings.bind(|| {
+            glob!("snapshots/cycle_detection/*.yaml", |path| {
+                let input: OpenAPI = openapi_from_yaml!(&path);
+                let result = generate(input);
+                assert_debug_snapshot!(result);
+            });
+        });
+        Ok(())
+    }
+
+    #[test]
     fn allof_inputs() -> Result<(), Box<dyn Error>> {
         let openapi: OpenAPI = openapi_from_yaml!("src/snapshots/allof/petstore.yaml");
         let output_directory = PathBuf::from_str("src/snapshots/allof")?;

--- a/src/snapshots/cycle_detection/RequestBodyCycle.yaml
+++ b/src/snapshots/cycle_detection/RequestBodyCycle.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/hj-goto/OpenAPI-Specification/e74e05b4401730ae5531dda0fecd9a15b0a2a0af/schemas/v3.0/schema.json
+openapi: 3.0.2
+info:
+  version: 1.0.17
+  title: Swagger Petstore - OpenAPI 3.0
+paths:
+  /pets:
+    post:
+      summary: Add a pet to the store
+      operationId: addPet
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Pet"
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        name:
+          type: string
+        parent:
+          $ref: "#/components/schemas/Pet"

--- a/src/snapshots/cycle_detection/RequestBodySeparatedCycle.yaml
+++ b/src/snapshots/cycle_detection/RequestBodySeparatedCycle.yaml
@@ -1,0 +1,38 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/hj-goto/OpenAPI-Specification/e74e05b4401730ae5531dda0fecd9a15b0a2a0af/schemas/v3.0/schema.json
+openapi: 3.0.2
+info:
+  version: 1.0.17
+  title: Swagger Petstore - OpenAPI 3.0
+paths:
+  /pets:
+    post:
+      summary: Add a pet to the store
+      operationId: addPet
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/A"
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+components:
+  schemas:
+    A:
+      type: object
+      properties:
+        name:
+          type: string
+        B:
+          $ref: "#/components/schemas/B"
+    B:
+      type: object
+      properties:
+        name:
+          type: string
+        A:
+          $ref: "#/components/schemas/A"

--- a/src/snapshots/cycle_detection/ResponseBodyCycle.yaml
+++ b/src/snapshots/cycle_detection/ResponseBodyCycle.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/hj-goto/OpenAPI-Specification/e74e05b4401730ae5531dda0fecd9a15b0a2a0af/schemas/v3.0/schema.json
+openapi: 3.0.2
+info:
+  version: 1.0.17
+  title: Swagger Petstore - OpenAPI 3.0
+paths:
+  /pets:
+    post:
+      summary: Add a pet to the store
+      operationId: addPet
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        name:
+          type: string
+        parent:
+          $ref: "#/components/schemas/Pet"

--- a/src/snapshots/cycle_detection/ResponseBodySeparatedCycle.yaml
+++ b/src/snapshots/cycle_detection/ResponseBodySeparatedCycle.yaml
@@ -1,0 +1,41 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/hj-goto/OpenAPI-Specification/e74e05b4401730ae5531dda0fecd9a15b0a2a0af/schemas/v3.0/schema.json
+openapi: 3.0.2
+info:
+  version: 1.0.17
+  title: Swagger Petstore - OpenAPI 3.0
+paths:
+  /pets:
+    post:
+      summary: Add a pet to the store
+      operationId: addPet
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/A"
+components:
+  schemas:
+    A:
+      type: object
+      properties:
+        name:
+          type: string
+        B:
+          $ref: "#/components/schemas/B"
+    B:
+      type: object
+      properties:
+        name:
+          type: string
+        A:
+          $ref: "#/components/schemas/A"

--- a/src/snapshots/heave__tests__cycle_detection.snap
+++ b/src/snapshots/heave__tests__cycle_detection.snap
@@ -1,0 +1,29 @@
+---
+source: src/main.rs
+input_file: src/snapshots/cycle_detection/RequestBodyCycle.yaml
+---
+GenerateResult {
+    outputs: [
+        Output {
+            expected_status_code: 200,
+            name: "addPet_200.hurl",
+            path: "/pets",
+            method: "POST",
+            header_parameters: [],
+            query_parameters: [],
+            asserts: [
+                "jsonpath \"$\" isCollection",
+            ],
+            request_body_parameter: "{\n  \"name\": \"\",\n  \"parent\": {\n    \"name\": \"\"\n  }\n}",
+        },
+    ],
+    diagnostics: [
+        RequestBodySchemaCycleDetected {
+            context: DiagnosticContext {
+                operation: "addPet",
+                path: "/pets",
+            },
+            jsonpath: "$.parent.parent",
+        },
+    ],
+}

--- a/src/snapshots/heave__tests__cycle_detection@RequestBodyCycle.yaml.snap
+++ b/src/snapshots/heave__tests__cycle_detection@RequestBodyCycle.yaml.snap
@@ -1,0 +1,29 @@
+---
+source: src/main.rs
+input_file: src/snapshots/cycle_detection/RequestBodyCycle.yaml
+---
+GenerateResult {
+    outputs: [
+        Output {
+            expected_status_code: 200,
+            name: "addPet_200.hurl",
+            path: "/pets",
+            method: "POST",
+            header_parameters: [],
+            query_parameters: [],
+            asserts: [
+                "jsonpath \"$\" isCollection",
+            ],
+            request_body_parameter: "{\n  \"name\": \"\",\n  \"parent\": {\n    \"name\": \"\"\n  }\n}",
+        },
+    ],
+    diagnostics: [
+        RequestBodySchemaCycleDetected {
+            context: DiagnosticContext {
+                operation: "addPet",
+                path: "/pets",
+            },
+            jsonpath: "$.parent.parent",
+        },
+    ],
+}

--- a/src/snapshots/heave__tests__cycle_detection@RequestBodySeparatedCycle.yaml.snap
+++ b/src/snapshots/heave__tests__cycle_detection@RequestBodySeparatedCycle.yaml.snap
@@ -1,0 +1,29 @@
+---
+source: src/main.rs
+input_file: src/snapshots/cycle_detection/RequestBodySeparatedCycle.yaml
+---
+GenerateResult {
+    outputs: [
+        Output {
+            expected_status_code: 200,
+            name: "addPet_200.hurl",
+            path: "/pets",
+            method: "POST",
+            header_parameters: [],
+            query_parameters: [],
+            asserts: [
+                "jsonpath \"$\" isCollection",
+            ],
+            request_body_parameter: "{\n  \"B\": {\n    \"A\": {\n      \"name\": \"\"\n    },\n    \"name\": \"\"\n  },\n  \"name\": \"\"\n}",
+        },
+    ],
+    diagnostics: [
+        RequestBodySchemaCycleDetected {
+            context: DiagnosticContext {
+                operation: "addPet",
+                path: "/pets",
+            },
+            jsonpath: "$.B.A.B",
+        },
+    ],
+}

--- a/src/snapshots/heave__tests__cycle_detection@ResponseBodyCycle.yaml.snap
+++ b/src/snapshots/heave__tests__cycle_detection@ResponseBodyCycle.yaml.snap
@@ -1,0 +1,32 @@
+---
+source: src/main.rs
+input_file: src/snapshots/cycle_detection/ResponseBodyCycle.yaml
+---
+GenerateResult {
+    outputs: [
+        Output {
+            expected_status_code: 200,
+            name: "addPet_200.hurl",
+            path: "/pets",
+            method: "POST",
+            header_parameters: [],
+            query_parameters: [],
+            asserts: [
+                "jsonpath \"$\" isCollection",
+                "#jsonpath \"$.name\" isString",
+                "#jsonpath \"$.parent\" isCollection",
+                "#jsonpath \"$.parent.name\" isString",
+            ],
+            request_body_parameter: "{\n  \"name\": \"\"\n}",
+        },
+    ],
+    diagnostics: [
+        ResponseBodySchemaCycleDetected {
+            context: DiagnosticContext {
+                operation: "addPet",
+                path: "/pets",
+            },
+            jsonpath: "$.parent.parent",
+        },
+    ],
+}

--- a/src/snapshots/heave__tests__cycle_detection@ResponseBodySeparatedCycle.yaml.snap
+++ b/src/snapshots/heave__tests__cycle_detection@ResponseBodySeparatedCycle.yaml.snap
@@ -1,0 +1,34 @@
+---
+source: src/main.rs
+input_file: src/snapshots/cycle_detection/ResponseBodySeparatedCycle.yaml
+---
+GenerateResult {
+    outputs: [
+        Output {
+            expected_status_code: 200,
+            name: "addPet_200.hurl",
+            path: "/pets",
+            method: "POST",
+            header_parameters: [],
+            query_parameters: [],
+            asserts: [
+                "jsonpath \"$\" isCollection",
+                "#jsonpath \"$.name\" isString",
+                "#jsonpath \"$.B\" isCollection",
+                "#jsonpath \"$.B.name\" isString",
+                "#jsonpath \"$.B.A\" isCollection",
+                "#jsonpath \"$.B.A.name\" isString",
+            ],
+            request_body_parameter: "{\n  \"name\": \"\"\n}",
+        },
+    ],
+    diagnostics: [
+        ResponseBodySchemaCycleDetected {
+            context: DiagnosticContext {
+                operation: "addPet",
+                path: "/pets",
+            },
+            jsonpath: "$.B.A.B",
+        },
+    ],
+}


### PR DESCRIPTION
This PR adds cycle detection when generating asserts and request bodies. Diagnostics are also added to help users debug these situations. Detection is pretty rudimentary in that it relies on the names of properties to determine if there is a cycle. This _could_ be improved to actually inspect the schema of the incoming object as well but that would be more difficult. This also wouldn't catch cycles that are more than a single level of separation. As in, if you had a jsonpath that looked like this: `$.A.B.C.A.B.C`, this would not be caught. But `$.A.B.A` would be caught.